### PR TITLE
Use tweepy exceptions, not errors

### DIFF
--- a/Based-Agent/twitter_utils.py
+++ b/Based-Agent/twitter_utils.py
@@ -22,7 +22,7 @@ class TwitterBot:
         try:
             tweet = self.api.update_status(content)
             return f"Successfully posted tweet with ID: {tweet.id}"
-        except tweepy.TweepError as e:
+        except tweepy.TweepException as e:
             return f"Error posting tweet: {str(e)}"
 
     def read_mentions(self, count: int = 10) -> List[Dict]:
@@ -43,7 +43,7 @@ class TwitterBot:
                 'user': mention.user.screen_name,
                 'created_at': mention.created_at
             } for mention in mentions]
-        except tweepy.TweepError as e:
+        except tweepy.TweepException as e:
             return [{'error': str(e)}]
 
     def reply_to_tweet(self, tweet_id: str, content: str) -> str:
@@ -68,7 +68,7 @@ class TwitterBot:
                 auto_populate_reply_metadata=True
             )
             return f"Successfully replied to tweet {tweet_id}"
-        except tweepy.TweepError as e:
+        except tweepy.TweepException as e:
             return f"Error replying to tweet: {str(e)}"
 
     def search_tweets(self, query: str, count: int = 10) -> List[Dict]:
@@ -90,5 +90,5 @@ class TwitterBot:
                 'user': tweet.user.screen_name,
                 'created_at': tweet.created_at
             } for tweet in tweets]
-        except tweepy.TweepError as e:
+        except tweepy.TweepException as e:
             return [{'error': str(e)}]


### PR DESCRIPTION
Ran into some error issues with twitter and switching from TweepError to TweepException prevented the bot from crashing

[Commit in Tweepy when changing from error to exception](https://github.com/tweepy/tweepy/commit/5c39cd159ef761500f3cb0292a3da40d5e250417)